### PR TITLE
Improving the examples to avoid potential grief

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ using (var services = serviceCollection.BuildServiceProvider())
 **.AddSerilogConfigurationLoader(<i>IConfiguration</i>, <i>SwitchableLogger</i>, <i>Func&lt;IConfiguration, ILogger&gt;</i>)** third argument specifies load function.
 ```C#
 loggingBuilder
+    .ClearProviders()
     .AddSerilog(switchableLogger, true)
     .AddSerilogConfigurationLoader(configuration, switchableLogger, 
         c => new Serilog.LoggerConfiguration().ReadFrom.Configuration(c).CreateLogger())


### PR DESCRIPTION
While running two integration tests using asp.net core integration test framework (WebApplicationFactory and such), we found that our code was using disposed logging providers/services scopes. It took quite a while to debug but finally traced it back to just clearing the providers when adding serilog in the ConfigureLogging.

Anyway, just proposing to update the example to help others. Perhaps a comment or description above might be better. 

Let me know what you think!

Thanks for creating the library, looking forward to getting it deployed.